### PR TITLE
Fix GitHub App ID configuration and improve setup documentation

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -53,6 +53,12 @@ steps:
           terraform plan -out=main.tfplan
         fi
 
+        # Check if plan was successful
+        if [ $? -ne 0 ]; then
+          echo "Terraform plan failed. Exiting."
+          exit 1
+        fi
+
         # Show plan
         terraform show main.tfplan
 
@@ -88,11 +94,13 @@ steps:
       - 'TF_VAR_github_token=${_GITHUB_TOKEN}'
       - 'TF_VAR_github_owner=${_GITHUB_OWNER}'
       - 'TF_VAR_gcp_project_id=${PROJECT_ID}'
+      - 'TF_VAR_github_app_id=${_GITHUB_APP_ID}'
 
 # Substitutions for variables
 substitutions:
   _GITHUB_TOKEN: 'projects/${PROJECT_ID}/secrets/github-token/versions/latest'
   _GITHUB_OWNER: 'dg-ghtest'  # Replace with your SDK GitHub org
+  _GITHUB_APP_ID: 'projects/${PROJECT_ID}/secrets/github-app-id/versions/latest'
 
 # Use a service account with appropriate permissions
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/terraform-automation@${PROJECT_ID}.iam.gserviceaccount.com'

--- a/setup/secrets.sh
+++ b/setup/secrets.sh
@@ -6,10 +6,16 @@ set -euo pipefail
 
 PROJECT_ID="${1}"
 GITHUB_TOKEN="${2}"
+GITHUB_APP_ID="${3:-}"
 
 if [[ -z "${PROJECT_ID:-}" ]] || [[ -z "${GITHUB_TOKEN:-}" ]]; then
-    echo "Usage: $0 <project_id> <github_token>"
-    echo "Example: $0 my-sdk-project ghp_xxxxxxxxxxxx"
+    echo "Usage: $0 <project_id> <github_token> [github_app_id]"
+    echo "Example: $0 my-sdk-project ghp_xxxxxxxxxxxx 123456"
+    echo ""
+    echo "Arguments:"
+    echo "  project_id     - Google Cloud Project ID"
+    echo "  github_token   - GitHub Personal Access Token or Fine-grained PAT"
+    echo "  github_app_id  - GitHub App ID (numeric, required for Cloud Build)"
     exit 1
 fi
 
@@ -54,6 +60,40 @@ else
       --role="roles/secretmanager.secretAccessor" \
       --project="$PROJECT_ID"
     echo "Access granted ✓"
+fi
+
+# Create secret for GitHub App ID (if provided)
+if [[ -n "${GITHUB_APP_ID:-}" ]]; then
+    if gcloud secrets describe github-app-id --project="$PROJECT_ID" >/dev/null 2>&1; then
+        echo "GitHub App ID secret already exists, updating with new value..."
+        echo "$GITHUB_APP_ID" | gcloud secrets versions add github-app-id \
+          --data-file=- \
+          --project="$PROJECT_ID"
+    else
+        echo "Creating GitHub App ID secret..."
+        echo "$GITHUB_APP_ID" | gcloud secrets create github-app-id \
+          --data-file=- \
+          --project="$PROJECT_ID"
+    fi
+    echo "GitHub App ID secret ready ✓"
+
+    # Grant access to the service account
+    echo "Granting access to terraform-automation service account for github-app-id..."
+    
+    # Check if IAM binding already exists
+    if gcloud secrets get-iam-policy github-app-id --project="$PROJECT_ID" --format="value(bindings.members)" | grep -q "$SA_EMAIL"; then
+        echo "Service account already has access to github-app-id secret"
+    else
+        gcloud secrets add-iam-policy-binding github-app-id \
+          --member="serviceAccount:$SA_EMAIL" \
+          --role="roles/secretmanager.secretAccessor" \
+          --project="$PROJECT_ID"
+        echo "Access granted ✓"
+    fi
+else
+    echo "⚠️  WARNING: GitHub App ID not provided. You'll need to create this secret manually:"
+    echo "   gcloud secrets create github-app-id --data-file=<(echo 'YOUR_GITHUB_APP_ID') --project=$PROJECT_ID"
+    echo "   gcloud secrets add-iam-policy-binding github-app-id --member='serviceAccount:$SA_EMAIL' --role='roles/secretmanager.secretAccessor' --project=$PROJECT_ID"
 fi
 
 echo "Secret setup completed!"


### PR DESCRIPTION
- Add github_app_id variable support to cloudbuild.yaml
- Fix terraform plan error handling to prevent invalid apply attempts
- Update secrets.sh script to create github-app-id secret with proper IAM bindings
- Reorganize SPEC.md setup steps: combine GitHub connection and secret creation
- Add clear instructions for finding GitHub App installation ID from GitHub UI
- Update documentation to clarify 1st gen connections use installation ID, not app ID