### PR TITLE
Fix syntax error: add missing closing brace for locals block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,6 +127,7 @@ locals {
         "notebooks/ @${var.github_owner}/docs-team"
       ]
     }
+  }
 }
 
 # Create shared Pub/Sub topic for Cloud Build triggers


### PR DESCRIPTION
## Problem
Cloud Build was failing with a Terraform syntax error:
```
Error: Unclosed configuration block
on main.tf line 60, in locals:
60: locals {
There is no closing brace for this block before the end of the file.
```

## Root Cause
The `locals` block starting at line 60 was missing a closing brace. The `repositories` map inside the locals block had its closing brace, but the outer `locals` block itself was never closed.

## Solution
- ✅ Added the missing closing brace at line 130 to properly close the `locals` block
- ✅ Verified Terraform syntax with `terraform validate` - now passes
- ✅ Checked brace balance - now correctly balanced

## Test Results
- `terraform fmt -check=true -diff=true` ✅ 
- `terraform validate` ✅
- `terraform plan` ✅ (successfully generates plan)
- Brace balance check ✅

This fixes the Cloud Build failure reported at: https://console.cloud.google.com/cloud-build/builds/45c0c611-98e5-47e7-a3c3-5adb2d361889

## Files Changed
- `main.tf` - Added missing closing brace for locals block