### PR TITLE
Fix GitHub provider configuration to use correct organization

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ terraform {
 # Configure the GitHub provider
 provider "github" {
   token = var.github_token
+  owner = var.github_owner
 }
 
 # Configure the Google provider


### PR DESCRIPTION
## Problem
The GitHub provider configuration was missing the `owner` parameter, causing repositories to be created under the authenticated user's personal account (`dangazineu`) instead of the intended organization (`dg-ghtest`).

## Root Cause
- The `provider "github"` block only specified `token = var.github_token`
- Without the `owner` parameter, the GitHub provider defaults to creating repositories under the authenticated user's account
- This caused the `test-sdk` repository to be created at `dangazineu/test-sdk` instead of `dg-ghtest/test-sdk`

## Solution
- ✅ **Added `owner = var.github_owner` to GitHub provider configuration**
- ✅ **Tested by recreating test-sdk repository under correct organization**
- ✅ **All future repositories will now be created in the correct organization**

## Files Changed
- `main.tf` - Added `owner = var.github_owner` to GitHub provider configuration

## Validation
- ✅ Pre-commit hooks passed (terraform fmt, validation, security checks)
- ✅ Successfully recreated test-sdk repository: `https://github.com/dg-ghtest/test-sdk`
- ✅ Terraform output confirms correct organization: `dg-ghtest/test-sdk`

## Impact
- **All future repository creations** will use the correct organization
- **Existing repositories** remain unaffected (no breaking changes)
- **Cloud Build triggers and service accounts** continue to work correctly

This is a critical fix to ensure infrastructure is deployed to the correct GitHub organization.

## Testing
The fix was validated by:
1. Removing test-sdk repository resources from Terraform state
2. Applying the GitHub provider configuration change
3. Recreating test-sdk repository - now correctly created under `dg-ghtest/test-sdk`
4. Verifying terraform outputs show correct organization URL